### PR TITLE
Reorganize sender code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-sender/remote-cache-server
+sender/sender
 sender/cache-dir
+receiver/receiver
 *.pprof

--- a/sender/backends/backend.go
+++ b/sender/backends/backend.go
@@ -1,6 +1,6 @@
 package backends
 
-import "github.com/ojarva/remote-cache-server/types"
+import "github.com/ojarva/remote-cache-server/sender/types"
 
 // CacheBackend is used to persist overflow when sending is either lagging behind or failing (for example, because of any connectivity issues).
 type CacheBackend interface {

--- a/sender/backends/filecachebackend.go
+++ b/sender/backends/filecachebackend.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ojarva/remote-cache-server/types"
+	"github.com/ojarva/remote-cache-server/sender/types"
 )
 
 // FileCacheBackend is a basic backend for storing overflow data in the filesystem, inside a single folder.

--- a/sender/backends/filecachebackend_test.go
+++ b/sender/backends/filecachebackend_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/ojarva/remote-cache-server/types"
+	"github.com/ojarva/remote-cache-server/sender/types"
 )
 
 func TestFileBackendFilenames(t *testing.T) {

--- a/sender/backends/flusher.go
+++ b/sender/backends/flusher.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/ojarva/remote-cache-server/types"
+	"github.com/ojarva/remote-cache-server/sender/types"
 )
 
 func FlushInMemoryToDisk(inMemoryBatches *types.InMemoryBatches, quitChannel chan struct{}, fileCacheBackend *FileCacheBackend, wg *sync.WaitGroup) {

--- a/sender/batcher/processor.go
+++ b/sender/batcher/processor.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/ojarva/remote-cache-server/backends"
-	"github.com/ojarva/remote-cache-server/types"
+	"github.com/ojarva/remote-cache-server/sender/backends"
+	"github.com/ojarva/remote-cache-server/sender/types"
 )
 
 // Processor processes incoming batches, either storing those in InMemoryBatches (if there's room) or to FileCacheBackend. If there's any room in InMemoryBatches, data from files stored by FileCacheBackend are preferred to avoid starvation.

--- a/sender/batcher/sender.go
+++ b/sender/batcher/sender.go
@@ -4,9 +4,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/ojarva/remote-cache-server/senders"
-	"github.com/ojarva/remote-cache-server/types"
-	"github.com/ojarva/remote-cache-server/utils"
+	"github.com/ojarva/remote-cache-server/sender/senders"
+	"github.com/ojarva/remote-cache-server/sender/types"
+	"github.com/ojarva/remote-cache-server/sender/utils"
 )
 
 // Send processes pending batches and tries to send those using sender specified in RemoteServerSettings.

--- a/sender/batcher/sender_test.go
+++ b/sender/batcher/sender_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ojarva/remote-cache-server/senders"
-	"github.com/ojarva/remote-cache-server/types"
+	"github.com/ojarva/remote-cache-server/sender/senders"
+	"github.com/ojarva/remote-cache-server/sender/types"
 )
 
 type FakeSender struct {

--- a/sender/batcher/splitter.go
+++ b/sender/batcher/splitter.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ojarva/remote-cache-server/types"
+	"github.com/ojarva/remote-cache-server/sender/types"
 )
 
 // BatchIncomingDataPoints reads incomingChannel and creates batches with preconfigured size (or time interval).

--- a/sender/batcher/splitter_test.go
+++ b/sender/batcher/splitter_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ojarva/remote-cache-server/types"
+	"github.com/ojarva/remote-cache-server/sender/types"
 )
 
 func TestBatchIncomingDataPoints(t *testing.T) {

--- a/sender/go.mod
+++ b/sender/go.mod
@@ -1,4 +1,4 @@
-module github.com/ojarva/remote-cache-server
+module github.com/ojarva/remote-cache-server/sender
 
 go 1.15
 

--- a/sender/go.sum
+++ b/sender/go.sum
@@ -1,2 +1,3 @@
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/ojarva/remote-cache-server v0.0.0-20210131191449-d9507850f257 h1:/r4XchK1SD7nR31JxBBxLVLl1h/zacM67yrcgYQeofU=

--- a/sender/runner/listeners.go
+++ b/sender/runner/listeners.go
@@ -1,0 +1,57 @@
+package runner
+
+import (
+	"bufio"
+	"log"
+	"net"
+	"strings"
+	"sync"
+)
+
+func handleIncomingConnection(client net.Conn, incomingChannel chan string) {
+	reader := bufio.NewReader(client)
+	for {
+		incoming, err := reader.ReadString('\n')
+		if err != nil {
+			log.Printf("Unable to read from %s: %s", client.RemoteAddr(), err)
+			return
+		}
+		incoming = strings.TrimRight(incoming, "\n")
+		if len(incoming) > 0 {
+			incomingChannel <- incoming
+		}
+	}
+}
+
+func listenIncomingConnections(l *net.TCPListener, newConnection chan net.Conn) {
+	for {
+		client, err := l.Accept()
+		if err != nil {
+			log.Print(err)
+			return
+		}
+		newConnection <- client
+	}
+}
+
+func listenIncoming(port int, incomingChannel chan string, wg *sync.WaitGroup, quitChannel chan struct{}) {
+	addr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: port}
+	l, err := net.ListenTCP("tcp4", addr)
+	if err != nil {
+		log.Fatalf("Unable to listen on port %d: %s", port, err)
+	}
+	defer l.Close()
+	newConnection := make(chan net.Conn, 10)
+	go listenIncomingConnections(l, newConnection)
+	log.Printf("Listening on localhost:%d", port)
+	for {
+		select {
+		case client := <-newConnection:
+			go handleIncomingConnection(client, incomingChannel)
+		case <-quitChannel:
+			log.Printf("Quit received; stopped listening")
+			wg.Done()
+			return
+		}
+	}
+}

--- a/sender/runner/main.go
+++ b/sender/runner/main.go
@@ -1,0 +1,85 @@
+package runner
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"time"
+
+	"github.com/ojarva/remote-cache-server/sender/backends"
+	"github.com/ojarva/remote-cache-server/sender/batcher"
+	"github.com/ojarva/remote-cache-server/sender/senders"
+	"github.com/ojarva/remote-cache-server/sender/types"
+)
+
+type Settings struct {
+	LocalPort            int
+	LocalDir             string
+	InMemoryBatchCount   int
+	SenderType           senders.SenderType
+	MaxBackoffTime       time.Duration
+	BatchSize            int
+	MaximumBatchWaitTime time.Duration
+	Protocol             string
+	RemoteHostname       string
+	RemotePort           int
+	Username             string
+	Password             string
+	Path                 string
+}
+
+func Run(settings Settings) error {
+	var err error
+	quitChannel := make(chan struct{})
+	osSignalChannel := make(chan os.Signal, 1)
+	signal.Notify(osSignalChannel, os.Interrupt)
+	go func() {
+		for range osSignalChannel {
+			log.Print("Received interrupt signal, shutting down")
+			close(quitChannel)
+		}
+	}()
+	var wg sync.WaitGroup
+	incomingChannel := make(chan string, 100)
+	batchChannel := make(chan types.OutgoingBatch, 100)
+	inMemoryBatchesAvailable := make(chan struct{}, settings.InMemoryBatchCount+5)
+	inMemorySlotAvailable := make(chan struct{}, 100)
+	inMemoryBatches := types.InMemoryBatches{SlotFreedUp: inMemorySlotAvailable}
+	var sender senders.Sender
+	switch settings.SenderType {
+	case senders.HTTP:
+		sender = &senders.HTTPSender{}
+	case senders.TCP:
+		sender = &senders.TCPSender{}
+	case senders.Dummy:
+		sender = &senders.DummySender{}
+	}
+	remoteServerSettings := senders.RemoteServerSettings{
+		Protocol:       settings.Protocol,
+		Hostname:       settings.RemoteHostname,
+		Port:           settings.RemotePort,
+		Username:       settings.Username,
+		Password:       settings.Password,
+		Path:           settings.Path,
+		MaxBackoffTime: settings.MaxBackoffTime,
+		Sender:         sender,
+	}
+
+	fileCacheBackend := &backends.FileCacheBackend{CacheDir: settings.LocalDir}
+	err = fileCacheBackend.Init()
+	if err != nil {
+		log.Fatalf("Unable to init file cache backend: %s", err)
+	}
+	inMemoryBatches.SetBatchCount(settings.InMemoryBatchCount)
+	wg.Add(1)
+	go backends.FlushInMemoryToDisk(&inMemoryBatches, quitChannel, fileCacheBackend, &wg)
+	wg.Add(1)
+	go listenIncoming(settings.LocalPort, incomingChannel, &wg, quitChannel)
+	wg.Add(1)
+	go batcher.BatchIncomingDataPoints(incomingChannel, batchChannel, settings.BatchSize, quitChannel, settings.MaximumBatchWaitTime, &wg)
+	go batcher.Send(&inMemoryBatches, inMemoryBatchesAvailable, remoteServerSettings)
+	go batcher.Processor(batchChannel, &inMemoryBatches, fileCacheBackend, inMemoryBatchesAvailable, quitChannel)
+	wg.Wait()
+	return nil
+}

--- a/sender/senders/senders.go
+++ b/sender/senders/senders.go
@@ -9,7 +9,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ojarva/remote-cache-server/types"
+	"github.com/ojarva/remote-cache-server/sender/types"
+)
+
+type SenderType int
+
+const (
+	HTTP SenderType = iota
+	TCP
+	Dummy
 )
 
 // RemoteServerSettings holds details for a remote server

--- a/sender/senders/tcpsender_test.go
+++ b/sender/senders/tcpsender_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/ojarva/remote-cache-server/senders"
-	"github.com/ojarva/remote-cache-server/types"
+	"github.com/ojarva/remote-cache-server/sender/senders"
+	"github.com/ojarva/remote-cache-server/sender/types"
 )
 
 func Example() {


### PR DESCRIPTION
This changeset contains no functional changes.

- Rename from github.com/ojarva/remote-cache-sender to
  github.com/ojarva/remote-cache-sender/sender as receiver is on
  the same repository.
- Remove all non-CLI-init related functionality from main package.